### PR TITLE
Introduce bdev_ubi.

### DIFF
--- a/mk/spdk.lib_deps.mk
+++ b/mk/spdk.lib_deps.mk
@@ -141,6 +141,7 @@ DEPDIRS-bdev_crypto := $(BDEV_DEPS_THREAD) accel
 DEPDIRS-bdev_delay := $(BDEV_DEPS_THREAD)
 DEPDIRS-bdev_iscsi := $(BDEV_DEPS_THREAD)
 DEPDIRS-bdev_malloc := $(BDEV_DEPS_THREAD) accel dma
+DEPDIRS-bdev_ubi := $(BDEV_DEPS_THREAD)
 DEPDIRS-bdev_null := $(BDEV_DEPS_THREAD)
 DEPDIRS-bdev_nvme = $(BDEV_DEPS_THREAD) accel nvme trace
 DEPDIRS-bdev_ocf := $(BDEV_DEPS_THREAD)

--- a/mk/spdk.modules.mk
+++ b/mk/spdk.modules.mk
@@ -8,6 +8,7 @@ BLOCKDEV_MODULES_LIST = bdev_malloc bdev_null bdev_nvme bdev_passthru bdev_lvol
 BLOCKDEV_MODULES_LIST += bdev_raid bdev_error bdev_gpt bdev_split bdev_delay
 BLOCKDEV_MODULES_LIST += bdev_zone_block
 BLOCKDEV_MODULES_LIST += blobfs blobfs_bdev blob_bdev blob lvol vmd nvme
+BLOCKDEV_MODULES_LIST += bdev_ubi
 
 # Some bdev modules don't have pollers, so they can directly run in interrupt mode
 INTR_BLOCKDEV_MODULES_LIST = bdev_malloc bdev_passthru bdev_error bdev_gpt bdev_split bdev_raid

--- a/module/bdev/Makefile
+++ b/module/bdev/Makefile
@@ -7,6 +7,7 @@ SPDK_ROOT_DIR := $(abspath $(CURDIR)/../..)
 include $(SPDK_ROOT_DIR)/mk/spdk.common.mk
 
 DIRS-y += delay error gpt lvol malloc null nvme passthru raid split zone_block
+DIRS-y += ubi
 
 DIRS-$(CONFIG_XNVME) += xnvme
 

--- a/module/bdev/ubi/Makefile
+++ b/module/bdev/ubi/Makefile
@@ -1,0 +1,18 @@
+#  SPDX-License-Identifier: BSD-3-Clause
+#  Copyright (C) 2015 Intel Corporation.
+#  All rights reserved.
+#
+
+SPDK_ROOT_DIR := $(abspath $(CURDIR)/../../..)
+include $(SPDK_ROOT_DIR)/mk/spdk.common.mk
+
+SO_VER := 5
+SO_MINOR := 0
+
+C_SRCS = bdev_ubi.c bdev_ubi_rpc.c bdev_ubi_flush.c \
+		 bdev_ubi_stripe.c bdev_ubi_io_channel.c
+LIBNAME = bdev_ubi
+
+SPDK_MAP_FILE = $(SPDK_ROOT_DIR)/mk/spdk_blank.map
+
+include $(SPDK_ROOT_DIR)/mk/spdk.lib.mk

--- a/module/bdev/ubi/README.md
+++ b/module/bdev/ubi/README.md
@@ -1,0 +1,73 @@
+# bdev_ubi
+
+## Introduction
+
+bdev_ubi provides an SPDK virtual bdev layered over another bdev, enabling copy-on-access for a base image.
+
+This can be utilized to set up a block device initialized with an image file,
+without the delay of an initial copy. With bdev_ubi, copying occurs lazily upon
+block access, rather than at the provisioning time.
+
+For instance, let's say you already have a bdev named "aio0" and you wish to
+populate it with data from `/opt/images/large-image.raw`. A conventional approach
+would be to copy `jammy.raw` to `aio0` using tools like spdk_dd, which can be
+time-consuming. However, with bdev_ubi, you can proceed as follows:
+
+```
+rpc.py bdev_ubi_create -n ubi0 -b aio0 -i /opt/images/large-image.raw --new-disk true
+```
+
+and rather than directly using `aio0`, use `ubi0` as the block device. This action
+completes almost instantly, eliminating the need for initial data copying. The
+actual data copying will occur lazily during I/O requests.
+
+## API
+
+### bdev_ubi_create
+
+Parameters:
+* `-n/--name [name]` (required): Name of the bdev to be created.
+* `-i/--image-path [path]` (required): Path to the image file.
+* `-b/--base-bdev [bdev]` (required): Name of base bdev.
+* `-z/--stripe-size-mb [size]` (optional): Stripe size in megabytes. Defaults to 1.
+
+### bdev_ubi_delete
+
+Parameters:
+* `-n/--name [name]` (required): Name of the bdev to be deleted.
+
+## Internals
+
+### Data Layout
+
+First 8MB of base bdev is reserved for metadata. Metadata consists of:
+* Magic bytes (9 bytes): `BDEV_UBI\0`
+* Metadata version major (2 bytes)
+* Metadata version minor (2 bytes)
+* stripe_size_mb (1 byte)
+* Stripe headers: 4 byte per stripes. Currently it specifies whether a stripe has
+  been fetched from image or not. 31-bits are reserved for future extension.
+* Padding to make the total size 8MB.
+
+Then at the 1MB offset the actual disk data starts.
+
+### Read/Write I/O operations
+
+If the stripe containing the requested block range hasn't been fetched yet, then a
+stripe fetch is enqueued. Once stripe has been fetched, the actual I/O operation is
+served.
+
+### Flush (aka sync)
+
+* Data for the requested range is flushed to base bdev.
+* Once data flush is finished, and if metadata has been modified in memory, then
+  metadata is first written and then flushed to base bdev.
+
+## Testing
+
+SPDK has a testing binary called `bdevio` which does some basic automated tests
+on a bdev. To use this for testing bdev_ubi, run:
+
+```
+test/ubi/ubi.sh
+```

--- a/module/bdev/ubi/bdev_ubi.c
+++ b/module/bdev/ubi/bdev_ubi.c
@@ -1,0 +1,712 @@
+/*   SPDX-License-Identifier: BSD-3-Clause
+ *   Copyright (C) 2017 Intel Corporation. All rights reserved.
+ *   Copyright (c) 2019 Mellanox Technologies LTD. All rights reserved.
+ */
+
+#include "bdev_ubi.h"
+#include "bdev_ubi_internal.h"
+
+#include "spdk/likely.h"
+#include "spdk/log.h"
+
+#include <inttypes.h>
+#include <errno.h>
+#include <string.h>
+
+/*
+ * Static function forward declarations
+ */
+static int ubi_initialize(void);
+static void ubi_finish(void);
+static int ubi_get_ctx_size(void);
+static int ubi_destruct(void *ctx);
+static void ubi_close_base_bdev(void *ctx);
+static int ubi_init_layout_params(struct ubi_bdev *ubi_bdev);
+static void ubi_start_read_metadata(struct ubi_bdev *ubi_bdev,
+									struct ubi_create_context *context);
+static void ubi_finish_read_metadata(struct spdk_bdev_io *bdev_io,
+									 bool success, void *cb_arg);
+static bool ubi_new_disk(const char* magic);
+static void ubi_init_metadata(struct ubi_bdev *ubi_bdev);
+static void ubi_finish_create(int status, struct ubi_create_context *context);
+static void ubi_submit_request(struct spdk_io_channel *ch,
+							   struct spdk_bdev_io *bdev_io);
+static bool ubi_io_type_supported(void *ctx, enum spdk_bdev_io_type io_type);
+static struct spdk_io_channel * ubi_get_io_channel(void *ctx);
+static void ubi_write_config_json(struct spdk_bdev *bdev,
+								  struct spdk_json_write_ctx *w);
+static int configure_base_bdev(const char *name, bool write,
+							   struct ubi_base_bdev_info *base_info);
+static void ubi_handle_base_bdev_event(enum spdk_bdev_event_type type,
+									   struct spdk_bdev *bdev, void *event_ctx);
+static bool ubi_bdev_find_by_base_bdev(struct spdk_bdev *base_bdev,
+									   struct ubi_bdev **_ubi_bdev,
+									   struct ubi_base_bdev_info **_base_info);
+static void ubi_handle_base_bdev_remove_event(struct spdk_bdev *base_bdev);
+static void ubi_set_version(struct ubi_metadata *metadata,
+							uint16_t major, uint16_t minor);
+static void ubi_get_version(struct ubi_metadata *metadata,
+							uint16_t *major, uint16_t *minor);
+
+/*
+ * Module Interface
+ */
+static struct spdk_bdev_module ubi_if = {
+	.name = "ubi",
+	.module_init = ubi_initialize,
+	.module_fini = ubi_finish,
+	.async_fini = false,
+	.async_init = false,
+	.get_ctx_size = ubi_get_ctx_size,
+};
+
+SPDK_BDEV_MODULE_REGISTER(ubi, &ubi_if)
+
+/*
+ * Block device operations
+ */
+static const struct spdk_bdev_fn_table ubi_fn_table = {
+	.destruct			= ubi_destruct,
+	.submit_request		= ubi_submit_request,
+	.io_type_supported	= ubi_io_type_supported,
+	.get_io_channel		= ubi_get_io_channel,
+	.write_config_json	= ubi_write_config_json,
+};
+
+static TAILQ_HEAD(, ubi_bdev) g_ubi_bdev_head = TAILQ_HEAD_INITIALIZER(g_ubi_bdev_head);
+
+/*
+ * ubi_initialize is called when the module is initialized.
+ */
+static int
+ubi_initialize(void)
+{
+	return 0;
+}
+
+/*
+ * ubi_finish is called when the module is finished.
+ */
+static void
+ubi_finish(void)
+{
+}
+
+/*
+ * ubi_get_ctx_size returns the size of I/O cotnext.
+ */
+static int
+ubi_get_ctx_size(void)
+{
+	return sizeof(struct ubi_bdev_io);
+}
+
+/*
+ * bdev_ubi_create. Creates a ubi_bdev and registers it.
+ *
+ * This will always call the callback stored in context->done_fn with the success
+ * status.
+ */
+void
+bdev_ubi_create(const struct spdk_ubi_bdev_opts *opts,
+				struct ubi_create_context *context)
+{
+	struct ubi_bdev *ubi_bdev;
+	int rc;
+
+	if (!opts) {
+		SPDK_ERRLOG("No options provided for Ubi bdev %s.\n", opts->name);
+		ubi_finish_create(-EINVAL, context);
+		return;
+	}
+
+	/*
+	 * By using calloc() we initialize the memory region to all 0, which also
+	 * ensures that metadata, strip_status, and metadata_dirty are all 0 initially.
+	 */
+	ubi_bdev = calloc(1, sizeof(struct ubi_bdev));
+	if (!ubi_bdev) {
+		SPDK_ERRLOG("could not allocate ubi_bdev %s\n", opts->name);
+		ubi_finish_create(-ENOMEM, context);
+		return;
+	}
+
+	/*
+	 * Save ubi_bdev in context so we can either register it (on success) or clean
+	 * it up (on failure) in ubi_finish_create().
+	 */
+	context->ubi_bdev = ubi_bdev;
+
+	ubi_bdev->bdev.name = strdup(opts->name);
+	if (!ubi_bdev->bdev.name) {
+		SPDK_ERRLOG("could not duplicate name for ubi_bdev %s\n", opts->name);
+		ubi_finish_create(-ENOMEM, context);
+		return;
+	}
+
+	/* Save the thread where the base device is opened. */
+	ubi_bdev->thread = spdk_get_thread();
+
+	rc = configure_base_bdev(opts->base_bdev_name, true, &ubi_bdev->base_bdev_info);
+	if (rc) {
+		UBI_ERRLOG(ubi_bdev, "could not get base image bdev\n");
+		ubi_finish_create(rc, context);
+		return;
+	}
+
+	/*
+	 * Initialize variables that determine the layout of both metadata and actual
+	 * data on base bdev.
+	 *
+	 * TODO: if this is not a new disk, we should read stripe_size_mb from metadata.
+	 */
+	ubi_bdev->stripe_size_mb = opts->stripe_size_mb;
+	strcpy(ubi_bdev->image_path, opts->image_path);
+	rc = ubi_init_layout_params(ubi_bdev);
+	if (rc)
+	{
+		ubi_finish_create(rc, context);
+		return;
+	}
+
+	/* Copy some properties from the underlying base bdev. */
+	struct spdk_bdev *base_bdev = ubi_bdev->base_bdev_info.bdev;
+	ubi_bdev->bdev.blocklen = base_bdev->blocklen;
+	ubi_bdev->bdev.blockcnt = base_bdev->blockcnt - ubi_bdev->data_offset_blocks;
+	ubi_bdev->bdev.write_cache = base_bdev->write_cache;
+
+	ubi_bdev->bdev.product_name = "Ubi disk";
+	ubi_bdev->bdev.ctxt = ubi_bdev;
+	ubi_bdev->bdev.fn_table = &ubi_fn_table;
+	ubi_bdev->bdev.module = &ubi_if;
+
+	ubi_bdev->bdev.optimal_io_boundary = ubi_bdev->stripe_block_count;
+	ubi_bdev->bdev.split_on_optimal_io_boundary = true;
+
+	spdk_io_device_register(
+		ubi_bdev,
+		ubi_create_channel_cb,
+		ubi_destroy_channel_cb,
+		sizeof(struct ubi_io_channel), ubi_bdev->bdev.name);
+	context->registerd = true;
+
+	// read metadata asynchronously.
+	ubi_start_read_metadata(ubi_bdev, context);
+}
+
+/*
+ * ubi_start_read_metadata initiates reading metadata from base bdev and returns.
+ * This doesn't block. Instead ubi_finish_read_metadata is called when reading is
+ * done.
+ */
+static void
+ubi_start_read_metadata(struct ubi_bdev *ubi_bdev, struct ubi_create_context *context)
+{
+	struct spdk_bdev_desc *base_desc = ubi_bdev->base_bdev_info.desc;
+	context->base_ch = spdk_bdev_get_io_channel(base_desc);
+	int offset = 0;
+	int block_cnt = UBI_METADATA_SIZE / ubi_bdev->bdev.blocklen;
+	int ret = spdk_bdev_read_blocks(
+				base_desc, context->base_ch, &ubi_bdev->metadata,
+				offset, block_cnt, ubi_finish_read_metadata, context);
+	if (ret)
+	{
+		ubi_finish_create(ret, context);
+	}
+}
+
+/*
+ * ubi_finish_read_metadata is called when reading metadata from base bdev finishes.
+ */
+static void
+ubi_finish_read_metadata(struct spdk_bdev_io *bdev_io, bool success, void *cb_arg)
+{
+	struct ubi_create_context *context = cb_arg;
+	spdk_bdev_free_io(bdev_io);
+	spdk_put_io_channel(context->base_ch);
+
+	if (!success)
+	{
+		ubi_finish_create(-EIO, context);
+		return;
+	}
+
+	struct ubi_metadata *metadata = &context->ubi_bdev->metadata;
+	if (ubi_new_disk(metadata->magic))
+	{
+		ubi_init_metadata(context->ubi_bdev);
+		ubi_finish_create(0, context);
+		return;
+	}
+	else if (memcmp(UBI_MAGIC, metadata->magic, UBI_MAGIC_SIZE))
+	{
+		UBI_ERRLOG(context->ubi_bdev, "Invalid magic.\n");
+		ubi_finish_create(-EINVAL, context);
+		return;
+	}
+
+	uint16_t versionMajor, versionMinor;
+	ubi_get_version(metadata, &versionMajor, &versionMinor);
+	if (versionMajor != UBI_VERSION_MAJOR || versionMinor != UBI_VERSION_MINOR)
+	{
+		UBI_ERRLOG(context->ubi_bdev,
+				   "Unsupported metadata version: %d.%d",
+				   versionMajor, versionMinor);
+		ubi_finish_create(-EINVAL, context);
+		return;
+	}
+
+	for (int i = 0; i < UBI_MAX_STRIPES; i++)
+	{
+		bool fetched = metadata->stripe_headers[i][0];
+		context->ubi_bdev->stripe_status[i] =
+			fetched ? STRIPE_FETCHED : STRIPE_NOT_FETCHED;
+	}
+
+	ubi_finish_create(0, context);
+}
+
+static bool
+ubi_new_disk(const char* magic)
+{
+	/*
+	 * Assume a new disk if metadata has been zeroed out.
+	 */
+	for (size_t i = 0; i < UBI_MAGIC_SIZE; i++)
+		if (magic[i] != 0)
+			return false;
+	return true;
+}
+
+static void
+ubi_init_metadata(struct ubi_bdev *ubi_bdev)
+{
+	memcpy(ubi_bdev->metadata.magic, UBI_MAGIC, UBI_MAGIC_SIZE);
+	ubi_set_version(&ubi_bdev->metadata, UBI_VERSION_MAJOR, UBI_VERSION_MINOR);
+	ubi_bdev->metadata.stripe_size_mb = ubi_bdev->stripe_size_mb;
+}
+
+/*
+ * ubi_finish_create is called when the ubi_bdev creation flow is done, either
+ * by success or failure. Non-zero "status" means a failure.
+ */
+static void
+ubi_finish_create(int status,
+				  struct ubi_create_context *context)
+{
+	struct ubi_bdev *ubi_bdev = context->ubi_bdev;
+
+	if (status == 0)
+	{
+		status = spdk_bdev_register(&ubi_bdev->bdev);
+		if (status != 0)
+		{
+			UBI_ERRLOG(ubi_bdev, "could not register ubi_bdev\n");
+			spdk_bdev_module_release_bdev(&ubi_bdev->bdev);
+		}
+		else
+		{
+			TAILQ_INSERT_TAIL(&g_ubi_bdev_head, ubi_bdev, tailq);
+		}
+	}
+
+	if (status != 0 && ubi_bdev)
+	{
+		if (ubi_bdev->base_bdev_info.desc)
+		{
+			spdk_bdev_close(ubi_bdev->base_bdev_info.desc);
+		}
+
+		if (context->registerd)
+		{
+			spdk_io_device_unregister(ubi_bdev, NULL);
+		}
+
+		free(ubi_bdev->bdev.name);
+		free(ubi_bdev);
+	}
+
+	context->done_fn(context->done_arg, &ubi_bdev->bdev, status);
+	free(context);
+}
+
+/*
+ * ubi_init_layout_params initializes variables related to layout of metadata
+ * and block data are layed out on base bdev.
+ */
+static int
+ubi_init_layout_params(struct ubi_bdev *ubi_bdev)
+{
+	// ensure base image exists, and get its size
+	struct stat statBuffer;
+	int statResult = stat(ubi_bdev->image_path, &statBuffer);
+	if (statResult < 0)
+	{
+		UBI_ERRLOG(ubi_bdev, "getting stats for %s failed: %s\n",
+				   ubi_bdev->image_path, strerror(errno));
+		return -EINVAL;
+	}
+
+	uint32_t blocklen = ubi_bdev->base_bdev_info.bdev->blocklen;
+	uint64_t blockcnt = ubi_bdev->base_bdev_info.bdev->blockcnt;
+
+	if (blockcnt * blocklen < (uint64_t) statBuffer.st_size + UBI_METADATA_SIZE)
+	{
+		UBI_ERRLOG(ubi_bdev,
+				   "base block device is smaller than image + metadata size\n");
+		return -EINVAL;
+	}
+
+	if (ubi_bdev->stripe_size_mb < 1 || ubi_bdev->stripe_size_mb > UBI_STRIPE_SIZE_MAX)
+	{
+		UBI_ERRLOG(ubi_bdev,
+				   "stripe_size_mb must be between 1 and %d (inclusive)\n",
+				   UBI_STRIPE_SIZE_MAX);
+		return -EINVAL;
+	}
+
+	if (ubi_bdev->stripe_size_mb & (ubi_bdev->stripe_size_mb - 1))
+	{
+		UBI_ERRLOG(ubi_bdev,
+				   "stripe_size_mb must be a power of 2\n");
+		return -EINVAL;
+	}
+
+	uint32_t stripSizeBytes = ubi_bdev->stripe_size_mb * 1024 * 1024;
+	if (stripSizeBytes < blocklen)
+	{
+		UBI_ERRLOG(ubi_bdev,
+				   "stripe size (%u bytes) can't be less than base bdev's blocklen (%u bytes)",
+				   stripSizeBytes, blocklen);
+		return -EINVAL;
+	}
+
+	if (UBI_METADATA_SIZE % blocklen)
+	{
+		UBI_ERRLOG(ubi_bdev,
+				   "metadata size (%d) must be a multiple of blocklen (%d)\n",
+				   UBI_METADATA_SIZE, blocklen);
+		return -EINVAL;
+	}
+
+	uint32_t r = (stripSizeBytes + blocklen - 1) / blocklen;
+	int log2_r = 0;
+	while (r > 1) {
+		r /= 2;
+		log2_r++;
+	}
+
+	ubi_bdev->stripe_block_count = (1 << log2_r);
+	ubi_bdev->stripe_shift = log2_r;
+	ubi_bdev->data_offset_blocks = UBI_METADATA_SIZE / blocklen;
+	ubi_bdev->image_block_count = (statBuffer.st_size + blocklen - 1) / blocklen;
+
+	return 0;
+}
+
+/*
+ * bdev_ubi_delete. Finds and unregisters a given bdev name.
+ */
+void
+bdev_ubi_delete(const char *bdev_name, spdk_delete_ubi_complete cb_fn, void *cb_arg)
+{
+	int rc;
+	rc = spdk_bdev_unregister_by_name(bdev_name, &ubi_if, cb_fn, cb_arg);
+	if (rc != 0) {
+		cb_fn(cb_arg, rc);
+	}
+}
+
+/* Callback for unregistering the IO device. */
+static void
+_device_unregister_cb(void *io_device)
+{
+	struct ubi_bdev *ubi_bdev  = io_device;
+
+	/* Done with this ubi_bdev. */
+	free(ubi_bdev->bdev.name);
+	free(ubi_bdev);
+}
+
+/*
+ * ubi_destruct. Given a pointer to a ubi_bdev, destruct it.
+ */
+static int
+ubi_destruct(void *ctx)
+{
+	struct ubi_bdev *ubi_bdev = ctx;
+
+	TAILQ_REMOVE(&g_ubi_bdev_head, ubi_bdev, tailq);
+
+	/* Unclaim the underlying bdev. */
+	spdk_bdev_module_release_bdev(ubi_bdev->base_bdev_info.bdev);
+
+	/* Close the underlying bdev in the same thread it was opened. */
+	if (ubi_bdev->thread && ubi_bdev->thread != spdk_get_thread())
+	{
+		spdk_thread_send_msg(ubi_bdev->thread, ubi_close_base_bdev,
+							 ubi_bdev->base_bdev_info.desc);
+	}
+	else
+	{
+		spdk_bdev_close(ubi_bdev->base_bdev_info.desc);
+	}
+
+	/* Unregister the io_device. */
+	spdk_io_device_unregister(ubi_bdev, _device_unregister_cb);
+
+	return 0;
+}
+
+/*
+ * ubi_close_base_bdev closes bdev given as context.
+ */
+static void
+ubi_close_base_bdev(void *ctx)
+{
+	struct spdk_bdev_desc *desc = ctx;
+
+	spdk_bdev_close(desc);
+}
+
+/*
+ * ubi_write_config_json writes out config parameters for the given bdev to a
+ * json writer.
+ */
+static void
+ubi_write_config_json(struct spdk_bdev *bdev, struct spdk_json_write_ctx *w)
+{
+	struct ubi_bdev *ubi_bdev = bdev->ctxt;
+
+	spdk_json_write_object_begin(w);
+
+	spdk_json_write_named_string(w, "method", "bdev_ubi_create");
+
+	spdk_json_write_named_object_begin(w, "params");
+	spdk_json_write_named_string(w, "name", bdev->name);
+	spdk_json_write_named_string(w, "base_bdev", ubi_bdev->base_bdev_info.bdev->name);
+	spdk_json_write_named_string(w, "image_path", ubi_bdev->image_path);
+	spdk_json_write_named_uint32(w, "stripe_size_mb", ubi_bdev->stripe_size_mb);
+	spdk_json_write_object_end(w);
+
+	spdk_json_write_object_end(w);
+}
+
+/*
+ * ubi_io_type_supported determines which I/O operations are supported.
+ */
+static bool
+ubi_io_type_supported(void *ctx, enum spdk_bdev_io_type io_type)
+{
+	/*
+	 * According to https://spdk.io/doc/bdev_module.html, only READ and WRITE are
+	 * necessary. We also support FLUSH to provide crash recovery.
+	 */
+	switch (io_type) {
+	case SPDK_BDEV_IO_TYPE_READ:
+	case SPDK_BDEV_IO_TYPE_WRITE:
+	case SPDK_BDEV_IO_TYPE_FLUSH:
+		return true;
+	case SPDK_BDEV_IO_TYPE_WRITE_ZEROES:
+		/*
+		 * Write zeros to given address range. We don't support it explicitly
+		 * yet. Generic bdev code is capable if emulating this by sending regular
+		 * writes.
+		 */
+	case SPDK_BDEV_IO_TYPE_RESET:
+		/*
+		 * Request to abort all I/O and return the underlying device to its
+		 * initial state.
+		 *
+		 * Not supported yet.
+		 */
+	case SPDK_BDEV_IO_TYPE_UNMAP:
+		/*
+		 * Often referred to as "trim" or "deallocate", and is a request to
+		 * mark a set of blocks as no longer containing valid data.
+		 *
+		 * Not supported yet.
+		 */
+	default:
+		return false;
+	}
+}
+
+/*
+ * ubi_submit_request is called when an I/O request arrives. It will enqueue
+ * an stripe fetch if necessary, and then enqueue the I/O request so it is
+ * served in the poller.
+ */
+static void
+ubi_submit_request(struct spdk_io_channel *_ch, struct spdk_bdev_io *bdev_io)
+{
+	struct ubi_io_channel *ch = spdk_io_channel_get_ctx(_ch);
+
+	if (bdev_io->type != SPDK_BDEV_IO_TYPE_FLUSH)
+	{
+		struct ubi_bdev *ubi_bdev = bdev_io->bdev->ctxt;
+
+		uint64_t start_block = bdev_io->u.bdev.offset_blocks;
+		uint64_t num_blocks = bdev_io->u.bdev.num_blocks;
+		uint64_t end_block = start_block + num_blocks - 1;
+
+		uint64_t start_stripe = start_block >> ubi_bdev->stripe_shift;
+		uint64_t end_stripe = end_block >> ubi_bdev->stripe_shift;
+		if (start_stripe != end_stripe)
+		{
+			/*
+			* this shouldn't happen because we set split_on_optimal_io_boundary
+			* to true.
+			*/
+			UBI_ERRLOG(ubi_bdev, "BUG: I/O cannot span stripe boundary!\n");
+			spdk_bdev_io_complete(bdev_io, SPDK_BDEV_IO_STATUS_FAILED);
+			return;
+		}
+
+		if (start_block < ubi_bdev->image_block_count &&
+			ubi_get_stripe_status(ubi_bdev, start_stripe) == STRIPE_NOT_FETCHED)
+		{
+			enqueue_stripe(ch, start_stripe);
+			ubi_set_stripe_status(ubi_bdev, start_stripe, STRIPE_INFLIGHT);
+		}
+	}
+
+	TAILQ_INSERT_TAIL(&ch->io, bdev_io, module_link);
+}
+
+/*
+ * ubi_get_io_channel return I/O channel pointer for the given ubi bdev.
+ */
+static struct spdk_io_channel *
+ubi_get_io_channel(void *ctx)
+{
+	struct bdev_ubi *bdev_ubi = ctx;
+
+	return spdk_get_io_channel(bdev_ubi);
+}
+
+/*
+ * configure_base_bdev opens and claims a bdev identified by then given name.
+ * Fills in "base_info" and returns success status.
+ */
+static int
+configure_base_bdev(const char *name, bool write,
+					struct ubi_base_bdev_info *base_info)
+{
+	struct spdk_bdev_desc *desc;
+	struct spdk_bdev *bdev;
+	int rc;
+
+	assert(spdk_get_thread() == spdk_thread_get_app_thread());
+
+	rc = spdk_bdev_open_ext(name, write, ubi_handle_base_bdev_event, NULL, &desc);
+	if (rc != 0) {
+		if (rc != -ENODEV) {
+			SPDK_ERRLOG("Unable to create desc on bdev '%s'\n", name);
+		}
+		return rc;
+	}
+
+	bdev = spdk_bdev_desc_get_bdev(desc);
+
+	rc = spdk_bdev_module_claim_bdev(bdev, desc, &ubi_if);
+	if (rc != 0) {
+		SPDK_ERRLOG("Unable to claim this bdev as it is already claimed\n");
+		spdk_bdev_close(desc);
+		return rc;
+	}
+
+	base_info->bdev = bdev;
+	base_info->desc = desc;
+
+	return 0;
+}
+
+/*
+ * ubi_handle_base_bdev_remove_event is callback which is called when of base
+ * bdevs trigger an event, e.g. when they're removed or resized.
+ */
+static void
+ubi_handle_base_bdev_event(enum spdk_bdev_event_type type,
+						   struct spdk_bdev *bdev,
+						   void *event_ctx)
+{
+	switch (type) {
+	case SPDK_BDEV_EVENT_REMOVE:
+		ubi_handle_base_bdev_remove_event(bdev);
+		break;
+	default:
+		SPDK_NOTICELOG("Unsupported bdev event: type %d\n", type);
+		break;
+	}
+}
+
+/*
+ * ubi_handle_base_bdev_remove_event is called if a base bdev is removed.
+ */
+static void
+ubi_handle_base_bdev_remove_event(struct spdk_bdev *base_bdev)
+{
+	struct ubi_bdev *ubi_bdev = NULL;
+	struct ubi_base_bdev_info *base_info;
+
+	if (!ubi_bdev_find_by_base_bdev(base_bdev, &ubi_bdev, &base_info)) {
+		SPDK_ERRLOG("bdev to remove '%s' not found\n", base_bdev->name);
+		return;
+	}
+
+	spdk_bdev_module_release_bdev(base_bdev);
+	spdk_bdev_close(base_info->desc);
+}
+
+/*
+ * ubi_bdev_find_by_base_bdev finds the bdev which owns the given base bdev.
+ */
+static bool
+ubi_bdev_find_by_base_bdev(
+	struct spdk_bdev *base_bdev,
+	struct ubi_bdev **_ubi_bdev,
+	struct ubi_base_bdev_info **_base_info)
+{
+	struct ubi_bdev *ubi_bdev;
+
+	TAILQ_FOREACH(ubi_bdev, &g_ubi_bdev_head, tailq) {
+		if (ubi_bdev->base_bdev_info.bdev == base_bdev) {
+			*_ubi_bdev = ubi_bdev;
+			*_base_info = &ubi_bdev->base_bdev_info;
+			return true;
+		}
+	}
+
+	return false;
+}
+
+static void
+store_littleendian_shortint(uint16_t n, uint8_t *mem)
+{
+	mem[0] = (n & 0xff);
+	mem[1] = (n >> 8);
+}
+
+static uint16_t
+load_littleendian_shortint(uint8_t *mem)
+{
+	uint16_t result = mem[0] | (((uint16_t) mem[1]) << 8);
+	return result;
+}
+
+static void
+ubi_set_version(struct ubi_metadata *metadata, uint16_t major, uint16_t minor)
+{
+	store_littleendian_shortint(major, metadata->versionMajor);
+	store_littleendian_shortint(minor, metadata->versionMinor);
+}
+
+static void
+ubi_get_version(struct ubi_metadata *metadata, uint16_t *major, uint16_t *minor)
+{
+	*major = load_littleendian_shortint(metadata->versionMajor);
+	*minor = load_littleendian_shortint(metadata->versionMinor);
+}
+
+SPDK_LOG_REGISTER_COMPONENT(bdev_ubi)

--- a/module/bdev/ubi/bdev_ubi.h
+++ b/module/bdev/ubi/bdev_ubi.h
@@ -1,0 +1,47 @@
+/*   SPDX-License-Identifier: BSD-3-Clause
+ *   Copyright (C) 2017 Intel Corporation. All rights reserved.
+ *   Copyright (c) 2019 Mellanox Technologies LTD. All rights reserved.
+ */
+
+#ifndef SPDK_BDEV_NULL_H
+#define SPDK_BDEV_NULL_H
+
+#include "spdk/stdinc.h"
+
+#define DEFAULT_STRIPE_SIZE_MB 1
+
+typedef void (*spdk_delete_ubi_complete)(void *cb_arg, int bdeverrno);
+
+struct spdk_bdev;
+struct spdk_uuid;
+
+/*
+ * Parameters to create a ubi bdev.
+ */
+struct spdk_ubi_bdev_opts {
+	const char *name;
+	const char *image_path;
+	const char *base_bdev_name;
+	uint32_t stripe_size_mb;
+};
+
+struct ubi_create_context {
+	void (*done_fn)(void *cb_arg, struct spdk_bdev *bdev, int status);
+	void *done_arg;
+
+	struct ubi_bdev *ubi_bdev;
+	bool registerd;
+
+	/* temporary channel used to read metadata */
+	struct spdk_io_channel *base_ch;
+};
+
+/*
+ * Functions called by rpc methods.
+ */
+void bdev_ubi_create(const struct spdk_ubi_bdev_opts *opts,
+					 struct ubi_create_context *context);
+void bdev_ubi_delete(const char *bdev_name, spdk_delete_ubi_complete cb_fn, 
+					 void *cb_arg);
+
+#endif /* SPDK_BDEV_NULL_H */

--- a/module/bdev/ubi/bdev_ubi_flush.c
+++ b/module/bdev/ubi/bdev_ubi_flush.c
@@ -1,0 +1,139 @@
+
+#include "bdev_ubi_internal.h"
+
+#include "spdk/likely.h"
+#include "spdk/log.h"
+
+/*
+ * Static function forward declarations
+ */
+static void ubi_data_flush_completion(struct spdk_bdev_io *bdev_io, bool success, void *cb_arg);
+static void ubi_metadata_write_completion(struct spdk_bdev_io *bdev_io, bool success, void *cb_arg);
+static void ubi_metadata_flush_completion(struct spdk_bdev_io *bdev_io, bool success, void *cb_arg);
+
+
+/*
+ * To process a flush (aka sync) request for a specified block range, the
+ * data is first flushed to the base bdev. If metadata is not dirty, the
+ * I/O request is marked as completed.
+ * 
+ * If metadata is dirty, it's first written and subsequently flushed to
+ * the base bdev. Then the I/O request is marked as completed.
+ */
+
+void
+ubi_submit_flush_request(struct ubi_bdev_io *ubi_io)
+{
+	struct ubi_bdev *ubi_bdev = ubi_io->ubi_bdev;
+
+	uint64_t start_block = ubi_io->block_offset + ubi_io->ubi_bdev->data_offset_blocks;
+	uint64_t num_blocks = ubi_io->block_count;
+
+	struct ubi_base_bdev_info *base_info = &ubi_bdev->base_bdev_info;
+	struct spdk_io_channel *base_ch = ubi_io->ubi_ch->base_channel;
+	int ret = spdk_bdev_flush_blocks(base_info->desc, base_ch, start_block, num_blocks,
+									 ubi_data_flush_completion, ubi_io);
+	if (ret)
+	{
+		UBI_ERRLOG(ubi_io->ubi_bdev,
+				   "flush (start: %lu, len: %lu) failed, data flush error: %s\n",
+				   start_block, num_blocks, strerror(-ret));
+		spdk_bdev_io_complete(
+			spdk_bdev_io_from_ctx(ubi_io),
+			SPDK_BDEV_IO_STATUS_FAILED);
+	}
+}
+
+static void
+ubi_data_flush_completion(struct spdk_bdev_io *bdev_io, bool success, void *cb_arg)
+{
+	struct ubi_bdev_io *ubi_io = cb_arg;
+	struct ubi_bdev *ubi_bdev = ubi_io->ubi_bdev;
+
+	spdk_bdev_free_io(bdev_io);
+
+	if (!success)
+	{
+		UBI_ERRLOG(ubi_io->ubi_bdev,
+				   "flush (start: %lu, len: %lu) failed (data flush failure).\n",
+				   ubi_io->block_offset, ubi_io->block_count);
+		return;
+	}
+
+	if (!ubi_bdev->metadata_dirty)
+	{
+		spdk_bdev_io_complete(spdk_bdev_io_from_ctx(ubi_io),
+							  SPDK_BDEV_IO_STATUS_SUCCESS);
+		return;
+	}
+
+	struct ubi_base_bdev_info *base_info = &ubi_bdev->base_bdev_info;
+	struct spdk_io_channel *base_ch = ubi_io->ubi_ch->base_channel;
+	
+	uint32_t num_blocks = UBI_METADATA_SIZE / ubi_bdev->bdev.blocklen;
+	int ret = spdk_bdev_write_blocks(base_info->desc, base_ch,
+									 &ubi_bdev->metadata, 0, num_blocks,
+									 ubi_metadata_write_completion, ubi_io);
+	if (ret)
+	{
+		UBI_ERRLOG(ubi_io->ubi_bdev,
+				   "flush (start: %lu, len: %lu) failed, metadata write error: %s.\n",
+				   ubi_io->block_offset, ubi_io->block_count, strerror(-ret));
+		spdk_bdev_io_complete(
+			spdk_bdev_io_from_ctx(ubi_io),
+			SPDK_BDEV_IO_STATUS_FAILED);
+	}
+}
+
+static void
+ubi_metadata_write_completion(struct spdk_bdev_io *bdev_io, bool success, void *cb_arg)
+{
+	struct ubi_bdev_io *ubi_io = cb_arg;
+	struct ubi_bdev *ubi_bdev = ubi_io->ubi_bdev;
+	spdk_bdev_free_io(bdev_io);
+
+	if (!success)
+	{
+		UBI_ERRLOG(ubi_io->ubi_bdev,
+				   "flush (start: %lu, len: %lu) failed (metadata write failure).\n",
+				   ubi_io->block_offset, ubi_io->block_count);
+		spdk_bdev_io_complete(spdk_bdev_io_from_ctx(ubi_io),
+							  SPDK_BDEV_IO_STATUS_FAILED);
+		return;
+	}
+
+	struct ubi_base_bdev_info *base_info = &ubi_bdev->base_bdev_info;
+	struct spdk_io_channel *base_ch = ubi_io->ubi_ch->base_channel;
+	uint32_t num_blocks = sizeof(ubi_bdev->metadata) / ubi_bdev->bdev.blocklen;
+	int ret = spdk_bdev_flush_blocks(base_info->desc, base_ch, 0, num_blocks,
+									 ubi_metadata_flush_completion, ubi_io);
+	if (ret)
+	{
+		UBI_ERRLOG(ubi_io->ubi_bdev,
+				   "flush failed (start: %lu, len: %lu), metadata flush error: %s.\n",
+				   ubi_io->block_offset, ubi_io->block_count, strerror(-ret));
+		spdk_bdev_io_complete(
+			spdk_bdev_io_from_ctx(ubi_io),
+			SPDK_BDEV_IO_STATUS_FAILED);
+	}
+}
+
+static void
+ubi_metadata_flush_completion(struct spdk_bdev_io *bdev_io, bool success, void *cb_arg)
+{
+	struct ubi_bdev_io *ubi_io = cb_arg;
+	spdk_bdev_free_io(bdev_io);
+
+	if (!success)
+	{
+		UBI_ERRLOG(ubi_io->ubi_bdev,
+				   "flush (start: %lu, len: %lu) failed (metadata flush failure).\n",
+				   ubi_io->block_offset, ubi_io->block_count);
+		spdk_bdev_io_complete(spdk_bdev_io_from_ctx(ubi_io),
+							  SPDK_BDEV_IO_STATUS_FAILED);
+		return;
+	}
+
+	spdk_bdev_io_complete(spdk_bdev_io_from_ctx(ubi_io),
+						  SPDK_BDEV_IO_STATUS_SUCCESS);
+}

--- a/module/bdev/ubi/bdev_ubi_internal.h
+++ b/module/bdev/ubi/bdev_ubi_internal.h
@@ -1,0 +1,181 @@
+#ifndef BDEV_UBI_INTERNAL_H
+#define BDEV_UBI_INTERNAL_H
+
+#include "spdk/stdinc.h"
+#include "spdk/bdev.h"
+#include "spdk/env.h"
+#include "spdk/thread.h"
+#include "spdk/json.h"
+#include "spdk/string.h"
+#include "spdk/bdev_module.h"
+
+#include "bdev_ubi.h"
+
+#include <liburing.h>
+
+#define UBI_METADATA_SIZE 8388608
+
+// support images upto 1TB = 2^40 (assuming 1MB stripe size)
+#define UBI_MAX_STRIPES (1024 * 1024)
+#define UBI_STRIPE_SIZE_MAX 8
+
+#define UBI_MAGIC "BDEV_UBI"
+#define UBI_MAGIC_SIZE 9
+#define UBI_VERSION_MAJOR 0
+#define UBI_VERSION_MINOR 1
+
+#define UBI_MAX_ACTIVE_STRIPE_FETCHES 8
+#define UBI_FETCH_QUEUE_SIZE 32768
+
+/*
+ * On-disk metadata for a ubi bdev.
+ */
+struct ubi_metadata {
+	char magic[UBI_MAGIC_SIZE];
+
+	/* Parsed as little-endian 16-bit integers. */
+	char versionMajor[2];
+	char versionMinor[2];
+
+	char stripe_size_mb;
+
+	/*
+	 * Currently stripe_headers[i] will be either 0 or 1, but reserve 31 more bits
+	 * per stripe for future extension.
+	 */
+	uint8_t stripe_headers[UBI_MAX_STRIPES][4];
+
+	/* Unused space reserved for future extension. */
+	uint8_t padding[UBI_METADATA_SIZE -
+					UBI_MAGIC_SIZE -
+					UBI_MAX_STRIPES * 4 - 5];
+};
+
+/*
+ * State we need to keep for a single base bdev.
+ */
+struct ubi_base_bdev_info {
+	struct spdk_bdev *bdev;
+	struct spdk_bdev_desc *desc;
+};
+
+/*
+ * Runtime status of a stripe.
+ */
+enum stripe_status {
+	STRIPE_NOT_FETCHED = 0,
+	STRIPE_INFLIGHT,
+	STRIPE_FAILED,
+	STRIPE_FETCHED
+};
+
+/*
+ * Block device's state. ubi_create creates and sets up a ubi_bdev.
+ * ubi_bdev->bdev is registered with spdk. When registering, a pointer to
+ * the ubi_bdev is saved in "bdev.ctxt".
+ */
+struct ubi_bdev {
+	struct spdk_bdev bdev;
+
+	struct ubi_base_bdev_info base_bdev_info;
+
+	char image_path[1024];
+	uint32_t stripe_size_mb;
+	uint32_t stripe_block_count;
+	uint32_t stripe_shift;
+	uint32_t data_offset_blocks;
+	uint64_t image_block_count;
+
+	enum stripe_status stripe_status[UBI_MAX_STRIPES];
+
+	struct ubi_metadata metadata;
+	bool metadata_dirty;
+
+	/*
+	 * Thread where ubi_bdev was initialized. It's essential to close the base
+	 * bdev in the same thread in which it was opened.
+	 */
+	struct spdk_thread *thread;
+
+	/* queue pointer */
+	TAILQ_ENTRY(ubi_bdev) tailq;
+};
+
+/*
+ * State for a stripe fetch operation.
+ */
+struct stripe_fetch {
+	/* Is this currently used for an ongoing stripe fetch? */
+	bool active;
+
+	/* Which stripe are we fetching? */
+	uint32_t stripe_idx;
+
+	/* Where will the data be stored at? */
+	uint8_t buf[1024 * 1024 * UBI_STRIPE_SIZE_MAX];
+
+	struct ubi_bdev *ubi_bdev;
+};
+
+
+/*
+ * Per thread state for ubi bdev.
+ */
+struct ubi_io_channel {
+	struct ubi_bdev *ubi_bdev;
+	struct spdk_poller *poller;
+	struct spdk_io_channel *base_channel;
+
+	/*
+	 * Stripe fetches are initially queued in "stripe_fetch_queue". During each
+	 * I/O poller iteration, if there's an available spot in stripe_fetches, a
+	 * stripe fetch is dequeued and initiated.
+	 */
+	struct stripe_fetch stripe_fetches[UBI_MAX_ACTIVE_STRIPE_FETCHES];
+
+	struct {
+		uint32_t entries[UBI_FETCH_QUEUE_SIZE];
+		uint32_t head;
+		uint32_t tail;
+	} stripe_fetch_queue;
+
+	/* io_uring stuff */
+	int image_file_fd;
+	struct io_uring image_file_ring;
+
+	/* queue pointer */
+	TAILQ_HEAD(, spdk_bdev_io) io;
+};
+
+/*
+ * per I/O operation state.
+ */
+struct ubi_bdev_io {
+	struct ubi_bdev *ubi_bdev;
+	struct ubi_io_channel *ubi_ch;
+
+	uint64_t block_offset;
+	uint64_t block_count;
+};
+
+/* bdev_ubi_flush.c */
+void ubi_submit_flush_request(struct ubi_bdev_io *ubi_io);
+
+/* bdev_ubi_stripe.c */
+void ubi_start_fetch_stripe(struct ubi_io_channel *base_ch, struct stripe_fetch *stripe_fetch);
+int ubi_complete_fetch_stripe(struct ubi_io_channel *ch);
+void enqueue_stripe(struct ubi_io_channel *ch, int stripe_idx);
+int dequeue_stripe(struct ubi_io_channel *ch);
+bool stripe_queue_empty(struct ubi_io_channel *ch);
+enum stripe_status ubi_get_stripe_status(struct ubi_bdev *ubi_bdev, int stripe_index);
+void ubi_set_stripe_status(struct ubi_bdev *ubi_bdev, int index, enum stripe_status status);
+
+/* bdev_ubi_io_channel.c */
+int ubi_create_channel_cb(void *io_device, void *ctx_buf);
+void ubi_destroy_channel_cb(void *io_device, void *ctx_buf);
+
+/* macros */
+#define UBI_ERRLOG(ubi_bdev, format, ...) \
+	SPDK_ERRLOG("[%s] " format, ubi_bdev->bdev.name __VA_OPT__(,) __VA_ARGS__)
+
+#endif

--- a/module/bdev/ubi/bdev_ubi_io_channel.c
+++ b/module/bdev/ubi/bdev_ubi_io_channel.c
@@ -1,0 +1,330 @@
+
+#include "bdev_ubi_internal.h"
+
+#include "spdk/likely.h"
+#include "spdk/log.h"
+
+/*
+ * Static function forward declarations
+ */
+static int ubi_io_poll(void *arg);
+static void get_buf_for_read_cb(struct spdk_io_channel *ch,  struct spdk_bdev_io *bdev_io, bool success);
+static int ubi_submit_read_request(struct ubi_bdev_io *ubi_io);
+static int ubi_submit_write_request(struct ubi_bdev_io *ubi_io);
+static void ubi_io_completion(struct spdk_bdev_io *bdev_io, bool success, void *cb_arg);
+static void ubi_init_ext_io_opts(struct spdk_bdev_io *bdev_io, struct spdk_bdev_ext_io_opts *opts);
+
+/*
+ * ubi_create_channel_cb is called when an I/O channel needs to be created. In the VM
+ * world this can happen for example when VMM's firmware needs to use the disk, or
+ * when the virtio device is initiated by the operating system.
+ */
+int
+ubi_create_channel_cb(void *io_device, void *ctx_buf)
+{
+	struct ubi_bdev *ubi_bdev = io_device;
+	struct ubi_io_channel *ch = ctx_buf;
+
+	ch->ubi_bdev = ubi_bdev;
+	TAILQ_INIT(&ch->io);
+	ch->poller = SPDK_POLLER_REGISTER(ubi_io_poll, ch, 0);
+
+	ch->base_channel = spdk_bdev_get_io_channel(ubi_bdev->base_bdev_info.desc);
+
+	ch->stripe_fetch_queue.head = 0;
+	ch->stripe_fetch_queue.tail = 0;
+
+	for (int i = 0; i < UBI_MAX_ACTIVE_STRIPE_FETCHES; i++)
+	{
+		ch->stripe_fetches[i].active = false;
+		ch->stripe_fetches[i].ubi_bdev = ubi_bdev;
+	}
+
+	ch->image_file_fd = open(ubi_bdev->image_path, O_RDONLY);
+	if (ch->image_file_fd < 0)
+	{
+		UBI_ERRLOG(ubi_bdev, "could not open %s: %s\n",
+				   ubi_bdev->image_path, strerror(errno));
+		return -EINVAL;
+	}
+
+	struct io_uring_params io_uring_params;
+	memset(&io_uring_params, 0, sizeof(io_uring_params));
+	io_uring_params.flags |= IORING_SETUP_SQPOLL;
+	io_uring_params.sq_thread_idle = 2000;
+
+	int rc = io_uring_queue_init_params(
+				UBI_MAX_ACTIVE_STRIPE_FETCHES,
+				&ch->image_file_ring,
+				&io_uring_params);
+	if (rc != 0)
+	{
+		UBI_ERRLOG(ubi_bdev, "Unable to setup io_uring: %s\n", strerror(-rc));
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
+/*
+ * ubi_destroy_channel_cb when an I/O channel needs to be destroyed.
+ */
+void
+ubi_destroy_channel_cb(void *io_device, void *ctx_buf)
+{
+	struct ubi_io_channel *ch = ctx_buf;
+	spdk_poller_unregister(&ch->poller);
+
+	if (close(ch->image_file_fd) != 0)
+	{
+		UBI_ERRLOG(ch->ubi_bdev, "Error closing file: %s\n", strerror(errno));
+	}
+
+	io_uring_queue_exit(&ch->image_file_ring);
+	spdk_put_io_channel(ch->base_channel);
+}
+
+/*
+ * ubi_io_poll is the poller function that is called regularly by SPDK.
+ */
+static int
+ubi_io_poll(void *arg)
+{
+	struct ubi_io_channel *ch = arg;
+	struct spdk_bdev_io	*bdev_io;
+	struct ubi_bdev *ubi_bdev = ch->ubi_bdev;
+
+	bool queues_empty = TAILQ_EMPTY(&ch->io) && stripe_queue_empty(ch);
+	int fetches_completed = ubi_complete_fetch_stripe(ch);
+
+	if (queues_empty && fetches_completed < 1) {
+		return SPDK_POLLER_IDLE;
+	}
+
+	if (queues_empty) {
+		// no items in queues to process, but might have some more fetches to finish.
+		return SPDK_POLLER_BUSY;
+	}
+
+	/*
+	 * Create a list of free stripes.
+	 */
+	int n_free_stripe_fetches = 0;
+	int free_stripe_fetches[UBI_MAX_ACTIVE_STRIPE_FETCHES];
+	for (int i = 0; i < UBI_MAX_ACTIVE_STRIPE_FETCHES; i++)
+	{
+		if (!ch->stripe_fetches[i].active)
+		{
+			free_stripe_fetches[n_free_stripe_fetches] = i;
+			n_free_stripe_fetches++;
+		}
+	}
+
+	/*
+	 * Dequeue and initiate stripe fetches.
+	 */
+	int free_stripe_fetch_idx = 0;
+	while (free_stripe_fetch_idx < n_free_stripe_fetches &&
+		   ch->stripe_fetch_queue.head != ch->stripe_fetch_queue.tail)
+	{
+		int stripe_idx = dequeue_stripe(ch);
+		int assigned_stripe_fetch_idx = free_stripe_fetches[free_stripe_fetch_idx];
+		struct stripe_fetch *stripe_fetch = &ch->stripe_fetches[assigned_stripe_fetch_idx];
+
+		stripe_fetch->stripe_idx = stripe_idx;
+		stripe_fetch->active = true;
+		ubi_start_fetch_stripe(ch, stripe_fetch);
+
+		free_stripe_fetch_idx++;
+	}
+
+	/*
+	 * Dequeue and process I/O requests.
+	 */
+	while (!TAILQ_EMPTY(&ch->io)) {
+		bdev_io = TAILQ_FIRST(&ch->io);
+
+		uint64_t start_block = bdev_io->u.bdev.offset_blocks;
+		if (bdev_io->type != SPDK_BDEV_IO_TYPE_FLUSH &&
+			start_block < ubi_bdev->image_block_count)
+		{
+			uint64_t stripe = start_block >> ubi_bdev->stripe_shift;
+			enum stripe_status stripe_status = ubi_get_stripe_status(ubi_bdev, stripe);
+
+			if (stripe_status == STRIPE_FAILED)
+			{
+				/*
+				 * The attempt to fetch the stripe containing the block was
+				 * unsuccessful. Dequeue it and mark it as failed.
+				 */
+				TAILQ_REMOVE(&ch->io, bdev_io, module_link);
+				spdk_bdev_io_complete(bdev_io, SPDK_BDEV_IO_STATUS_FAILED);
+				continue;
+			}
+			else if (stripe_status == STRIPE_INFLIGHT)
+			{
+				/*
+				 * The stripe containing the block is currently being fetched.
+				 * Halt the loop to ensure I/O requests are addressed in the
+				 * order they were received.
+				 */
+				break;
+			}
+			else if (stripe_status == STRIPE_NOT_FETCHED)
+			{
+				/*
+				 * This is a programming error. Such a scenario should never arise.
+				 * If an I/O request from the base image was enqueued, the fetching
+				 * process should have commenced. 
+				 */
+				UBI_ERRLOG(ch->ubi_bdev,
+						   "BUG: I/O for block %lu enqueued, but stripe %lu isn't enqueued.\n",
+						   start_block, stripe);
+
+				TAILQ_REMOVE(&ch->io, bdev_io, module_link);
+				spdk_bdev_io_complete(bdev_io, SPDK_BDEV_IO_STATUS_FAILED);
+				continue;
+			}
+		}
+
+		/*
+		 * At this point, the block is either beyond the base image size, or its
+		 * stripe has been fetched. Hence, dequeue and service it.
+		 */
+
+		TAILQ_REMOVE(&ch->io, bdev_io, module_link);
+
+		struct ubi_bdev_io *ubi_io = (struct ubi_bdev_io *) bdev_io->driver_ctx;
+		ubi_io->ubi_bdev = ubi_bdev;
+		ubi_io->ubi_ch = ch;
+		ubi_io->block_offset = bdev_io->u.bdev.offset_blocks;
+		ubi_io->block_count = bdev_io->u.bdev.num_blocks;
+
+		switch (bdev_io->type) {
+		case SPDK_BDEV_IO_TYPE_READ:
+		{
+			int len = bdev_io->u.bdev.num_blocks * bdev_io->bdev->blocklen;
+			spdk_bdev_io_get_buf(
+				bdev_io,
+				get_buf_for_read_cb,
+				len);
+			break;
+		}
+		case SPDK_BDEV_IO_TYPE_WRITE:
+			ubi_submit_write_request(ubi_io);
+			break;
+		case SPDK_BDEV_IO_TYPE_FLUSH:
+			ubi_submit_flush_request(ubi_io);
+			break;
+		default:
+			spdk_bdev_io_complete(bdev_io, SPDK_BDEV_IO_STATUS_FAILED);
+			break;
+		}
+	}
+
+	return SPDK_POLLER_BUSY;
+}
+
+/*
+ * get_buf_for_read_cb
+ */
+static void
+get_buf_for_read_cb(struct spdk_io_channel *ch, 
+					struct spdk_bdev_io *bdev_io,
+					bool success)
+{
+	struct ubi_bdev_io *ubi_io = (struct ubi_bdev_io *) bdev_io->driver_ctx;
+
+	if (!success) {
+		spdk_bdev_io_complete(bdev_io, SPDK_BDEV_IO_STATUS_FAILED);
+		return;
+	}
+
+	int ret = ubi_submit_read_request(ubi_io);
+
+	if (spdk_unlikely(ret != 0)) {
+		spdk_bdev_io_complete(bdev_io, SPDK_BDEV_IO_STATUS_FAILED);
+	}
+}
+
+/*
+ * ubi_submit_read_request processes a read I/O request. At this point the
+ * stripe containing the address range for this I/O has been fetched, so
+ * we can just redirect the I/O to the base bdev.
+ */
+static int
+ubi_submit_read_request(struct ubi_bdev_io *ubi_io)
+{
+	struct spdk_bdev_io *bdev_io = spdk_bdev_io_from_ctx(ubi_io);
+
+	struct spdk_bdev_ext_io_opts io_opts;
+	ubi_init_ext_io_opts(bdev_io, &io_opts);
+
+	struct ubi_bdev *ubi_bdev = ubi_io->ubi_bdev;
+	struct ubi_base_bdev_info *base_info = &ubi_bdev->base_bdev_info;
+	struct spdk_io_channel *base_ch = ubi_io->ubi_ch->base_channel;
+
+	uint64_t start_block = bdev_io->u.bdev.offset_blocks + ubi_bdev->data_offset_blocks;
+	uint64_t num_blocks = bdev_io->u.bdev.num_blocks;
+	int ret = spdk_bdev_readv_blocks_ext(base_info->desc, base_ch,
+					 bdev_io->u.bdev.iovs, bdev_io->u.bdev.iovcnt,
+					 start_block, num_blocks, ubi_io_completion,
+					 ubi_io, &io_opts);
+	return ret;
+}
+
+/*
+ * ubi_submit_write_request processes a write I/O request. At this point the
+ * stripe containing the address range for this I/O has been fetched, so
+ * we can just redirect the I/O to the base bdev.
+ */
+static int
+ubi_submit_write_request(struct ubi_bdev_io *ubi_io)
+{
+	struct spdk_bdev_io *bdev_io = spdk_bdev_io_from_ctx(ubi_io);
+
+	struct spdk_bdev_ext_io_opts io_opts;
+	ubi_init_ext_io_opts(bdev_io, &io_opts);
+
+	struct ubi_bdev *ubi_bdev = ubi_io->ubi_bdev;
+
+	uint64_t start_block = bdev_io->u.bdev.offset_blocks + ubi_bdev->data_offset_blocks;
+	uint64_t num_blocks = bdev_io->u.bdev.num_blocks;
+
+	struct ubi_base_bdev_info *base_info = &ubi_io->ubi_bdev->base_bdev_info;
+	struct spdk_io_channel *base_ch = ubi_io->ubi_ch->base_channel;
+	int ret = spdk_bdev_writev_blocks_ext(base_info->desc, base_ch,
+					bdev_io->u.bdev.iovs, bdev_io->u.bdev.iovcnt,
+					start_block, num_blocks, ubi_io_completion,
+					ubi_io, &io_opts);
+	return ret;
+}
+
+/*
+ * ubi_io_completion cleans up and marks the I/O request as completed.
+ */
+static void
+ubi_io_completion(struct spdk_bdev_io *bdev_io, bool success, void *cb_arg)
+{
+	struct ubi_bdev_io *ubi_io = cb_arg;
+
+	spdk_bdev_free_io(bdev_io);
+
+	spdk_bdev_io_complete(spdk_bdev_io_from_ctx(ubi_io), success ?
+				   SPDK_BDEV_IO_STATUS_SUCCESS :
+				   SPDK_BDEV_IO_STATUS_FAILED);
+}
+
+/*
+ * ubi_init_ext_io_opts fills in options for a request to the base bdev.
+ */
+static void
+ubi_init_ext_io_opts(struct spdk_bdev_io *bdev_io,
+					 struct spdk_bdev_ext_io_opts *opts)
+{
+	memset(opts, 0, sizeof(*opts));
+	opts->size = sizeof(*opts);
+	opts->memory_domain = bdev_io->u.bdev.memory_domain;
+	opts->memory_domain_ctx = bdev_io->u.bdev.memory_domain_ctx;
+	opts->metadata = bdev_io->u.bdev.md_buf;
+}

--- a/module/bdev/ubi/bdev_ubi_rpc.c
+++ b/module/bdev/ubi/bdev_ubi_rpc.c
@@ -1,0 +1,148 @@
+/*   SPDX-License-Identifier: BSD-3-Clause
+ *   Copyright (C) 2017 Intel Corporation. All rights reserved.
+ *   Copyright (c) 2019 Mellanox Technologies LTD. All rights reserved.
+ */
+
+#include "spdk/rpc.h"
+#include "spdk/util.h"
+#include "spdk/string.h"
+#include "spdk/bdev_module.h"
+#include "spdk/log.h"
+
+#include "bdev_ubi.h"
+
+struct rpc_construct_ubi {
+	char *name;
+	char *image_path;
+	char *base_bdev_name;
+	uint32_t stripe_size_mb;
+};
+
+static void
+free_rpc_construct_ubi(struct rpc_construct_ubi *req)
+{
+	free(req->name);
+	free(req->image_path);
+	free(req->base_bdev_name);
+}
+
+static const struct spdk_json_object_decoder rpc_construct_ubi_decoders[] = {
+	{"name", offsetof(struct rpc_construct_ubi, name), spdk_json_decode_string},
+	{"image_path", offsetof(struct rpc_construct_ubi, image_path), spdk_json_decode_string},
+	{"base_bdev", offsetof(struct rpc_construct_ubi, base_bdev_name), spdk_json_decode_string},
+	{"stripe_size_mb", offsetof(struct rpc_construct_ubi, stripe_size_mb), spdk_json_decode_uint32, true}
+};
+
+static void
+bdev_ubi_create_done(void *cb_arg, struct spdk_bdev *bdev, int status)
+{
+	struct spdk_jsonrpc_request *request = cb_arg;
+	if (status < 0)
+	{
+		spdk_jsonrpc_send_error_response(request, status, spdk_strerror(-status));
+	}
+	else if (status > 0)
+	{
+		spdk_jsonrpc_send_error_response_fmt(
+			request,
+			SPDK_JSONRPC_ERROR_INVALID_PARAMS,
+			"error code: %d.", status);
+	}
+	else
+	{
+		struct spdk_json_write_ctx *w = spdk_jsonrpc_begin_result(request);
+		spdk_json_write_string(w, bdev->name);
+		spdk_jsonrpc_end_result(request, w);
+	}
+}
+
+/*
+ * rpc_bdev_ubi_create handles an rpc request to create a bdev_ubi.
+ */
+static void
+rpc_bdev_ubi_create(struct spdk_jsonrpc_request *request,
+		    		const struct spdk_json_val *params)
+{
+	struct rpc_construct_ubi req = {};
+	struct spdk_ubi_bdev_opts opts = {};
+
+	// set optional parameters. spdk_json_decode_object will overwrite if provided.
+	req.stripe_size_mb = DEFAULT_STRIPE_SIZE_MB;
+
+	if (spdk_json_decode_object(params, rpc_construct_ubi_decoders,
+								SPDK_COUNTOF(rpc_construct_ubi_decoders),
+								&req))
+	{
+		SPDK_DEBUGLOG(bdev_ubi, "spdk_json_decode_object failed\n");
+		spdk_jsonrpc_send_error_response(request, SPDK_JSONRPC_ERROR_INTERNAL_ERROR,
+						 				 "spdk_json_decode_object failed");
+		goto cleanup;
+	}
+
+	opts.name = req.name;
+	opts.image_path = req.image_path;
+	opts.base_bdev_name = req.base_bdev_name;
+	opts.stripe_size_mb = req.stripe_size_mb;
+
+	struct ubi_create_context *context = calloc(1, sizeof(struct ubi_create_context));
+	context->done_fn = bdev_ubi_create_done;
+	context->done_arg = request;
+
+	bdev_ubi_create(&opts, context);
+
+cleanup:
+	free_rpc_construct_ubi(&req);
+}
+SPDK_RPC_REGISTER("bdev_ubi_create", rpc_bdev_ubi_create, SPDK_RPC_RUNTIME)
+
+
+struct rpc_delete_ubi {
+	char *name;
+};
+
+static void
+free_rpc_delete_ubi(struct rpc_delete_ubi *req)
+{
+	free(req->name);
+}
+
+static const struct spdk_json_object_decoder rpc_delete_ubi_decoders[] = {
+	{"name", offsetof(struct rpc_delete_ubi, name), spdk_json_decode_string},
+};
+
+static void
+rpc_bdev_ubi_delete_cb(void *cb_arg, int bdeverrno)
+{
+	struct spdk_jsonrpc_request *request = cb_arg;
+
+	if (bdeverrno == 0) {
+		spdk_jsonrpc_send_bool_response(request, true);
+	} else {
+		spdk_jsonrpc_send_error_response(request, bdeverrno, spdk_strerror(-bdeverrno));
+	}
+}
+
+static void
+rpc_bdev_ubi_delete(struct spdk_jsonrpc_request *request,
+		     const struct spdk_json_val *params)
+{
+	struct rpc_delete_ubi req = {NULL};
+
+	if (spdk_json_decode_object(params, rpc_delete_ubi_decoders,
+				    SPDK_COUNTOF(rpc_delete_ubi_decoders),
+				    &req)) {
+		spdk_jsonrpc_send_error_response(request, SPDK_JSONRPC_ERROR_INTERNAL_ERROR,
+						 "spdk_json_decode_object failed");
+		goto cleanup;
+	}
+
+	bdev_ubi_delete(req.name, rpc_bdev_ubi_delete_cb, request);
+
+	free_rpc_delete_ubi(&req);
+
+	return;
+
+cleanup:
+	free_rpc_delete_ubi(&req);
+}
+SPDK_RPC_REGISTER("bdev_ubi_delete", rpc_bdev_ubi_delete, SPDK_RPC_RUNTIME)

--- a/module/bdev/ubi/bdev_ubi_stripe.c
+++ b/module/bdev/ubi/bdev_ubi_stripe.c
@@ -1,0 +1,142 @@
+
+#include "bdev_ubi_internal.h"
+
+#include "spdk/likely.h"
+#include "spdk/log.h"
+
+/*
+ * Static function forward declarations
+ */
+static void write_stripe_io_completion(struct spdk_bdev_io *bdev_io, bool success, void *cb_arg);
+static void ubi_fail_stripe_fetch(struct stripe_fetch *stripe_fetch);
+
+void
+ubi_start_fetch_stripe(struct ubi_io_channel *ch, struct stripe_fetch *stripe_fetch)
+{
+	struct ubi_bdev *ubi_bdev = ch->ubi_bdev;
+	struct io_uring *ring = &ch->image_file_ring;
+	struct io_uring_sqe *sqe = io_uring_get_sqe(ring);
+	uint32_t stripe_idx = stripe_fetch->stripe_idx;
+
+	uint64_t offset = ubi_bdev->stripe_size_mb * 1024L * 1024L * stripe_idx;
+	uint32_t nbytes = ubi_bdev->stripe_size_mb * 1024L * 1024L;
+
+	io_uring_prep_read(sqe, ch->image_file_fd, stripe_fetch->buf, nbytes, offset);
+	io_uring_sqe_set_data(sqe, stripe_fetch);
+
+	int ret = io_uring_submit(ring);
+	if (ret < 0)
+	{
+		UBI_ERRLOG(ubi_bdev,
+				   "fetching stripe %d failed, io_uring_submit error: %s\n",
+					stripe_idx, strerror(-ret));
+		ubi_fail_stripe_fetch(stripe_fetch);
+	}
+}
+
+int
+ubi_complete_fetch_stripe(struct ubi_io_channel *ch)
+{
+	struct io_uring *ring = &ch->image_file_ring;
+	struct io_uring_cqe *cqe;
+
+	int ret = io_uring_peek_cqe(ring, &cqe);
+	if (ret == -EAGAIN) {
+		return 0;
+	} else if (ret != 0) {
+		UBI_ERRLOG(ch->ubi_bdev, "io_uring_peek_cqe: %s\n", strerror(-ret));
+		return -1;
+	}
+
+	struct stripe_fetch *stripe_fetch = io_uring_cqe_get_data(cqe);
+	uint64_t offset = ch->ubi_bdev->stripe_size_mb * 1024L * 1024L * stripe_fetch->stripe_idx;
+	uint32_t nbytes = ch->ubi_bdev->stripe_size_mb * 1024L * 1024L;
+
+	if (cqe->res < 0) {
+		UBI_ERRLOG(ch->ubi_bdev,
+				   "fetching stripe %d failed while checking cqe->res: %s\n",
+				   stripe_fetch->stripe_idx, strerror(-cqe->res));
+		ubi_fail_stripe_fetch(stripe_fetch);
+		return -1;
+	}
+
+	/* Mark the completion as seen. */
+	io_uring_cqe_seen(ring, cqe);
+
+	/*
+	 * Now that we have read the stripe and have it in memory, write it to the
+	 * base bdev.
+	 */
+	struct ubi_bdev *ubi_bdev = ch->ubi_bdev;
+	struct ubi_base_bdev_info *base_info = &ubi_bdev->base_bdev_info;
+
+	ret = spdk_bdev_write(base_info->desc, ch->base_channel,
+						  stripe_fetch->buf, offset + UBI_METADATA_SIZE,
+						  nbytes, write_stripe_io_completion, stripe_fetch);
+	if (ret != 0)
+	{
+		UBI_ERRLOG(ch->ubi_bdev,
+				   "fetching stripe %d failed, spdk_bdev_write error: %s\n",
+				   stripe_fetch->stripe_idx, strerror(-ret));
+		ubi_fail_stripe_fetch(stripe_fetch);
+		return -1;
+	}
+
+	return 1;
+}
+
+static void
+write_stripe_io_completion(struct spdk_bdev_io *bdev_io, bool success, void *cb_arg)
+{
+	spdk_bdev_free_io(bdev_io);
+
+	struct stripe_fetch *stripe_fetch = cb_arg;
+	ubi_set_stripe_status(stripe_fetch->ubi_bdev, stripe_fetch->stripe_idx, STRIPE_FETCHED);
+	stripe_fetch->ubi_bdev->metadata_dirty = true;
+	stripe_fetch->active = false;
+}
+
+static void
+ubi_fail_stripe_fetch(struct stripe_fetch *stripe_fetch)
+{
+	ubi_set_stripe_status(stripe_fetch->ubi_bdev, stripe_fetch->stripe_idx, STRIPE_FAILED);
+	stripe_fetch->active = false;
+}
+
+void
+enqueue_stripe(struct ubi_io_channel *ch, int stripe_idx)
+{
+	ch->stripe_fetch_queue.entries[ch->stripe_fetch_queue.tail] = stripe_idx;
+	ch->stripe_fetch_queue.tail = (ch->stripe_fetch_queue.tail + 1) & (UBI_FETCH_QUEUE_SIZE - 1);
+}
+
+int
+dequeue_stripe(struct ubi_io_channel *ch)
+{
+	int stripe_idx = ch->stripe_fetch_queue.entries[ch->stripe_fetch_queue.head];
+	ch->stripe_fetch_queue.head = (ch->stripe_fetch_queue.head + 1) & (UBI_FETCH_QUEUE_SIZE - 1);
+	return stripe_idx;
+}
+
+bool
+stripe_queue_empty(struct ubi_io_channel *ch)
+{
+	return ch->stripe_fetch_queue.head == ch->stripe_fetch_queue.tail;
+}
+
+enum stripe_status
+ubi_get_stripe_status(struct ubi_bdev *ubi_bdev, int index)
+{
+	return ubi_bdev->stripe_status[index];
+}
+
+void
+ubi_set_stripe_status(struct ubi_bdev *ubi_bdev, int index, enum stripe_status status)
+{
+	ubi_bdev->stripe_status[index] = status;
+
+	if (status == STRIPE_FETCHED)
+	{
+		ubi_bdev->metadata.stripe_headers[index][0] = 1;
+	}
+}

--- a/python/spdk/rpc/bdev.py
+++ b/python/spdk/rpc/bdev.py
@@ -326,6 +326,32 @@ def bdev_malloc_delete(client, name):
     return client.call('bdev_malloc_delete', params)
 
 
+def bdev_ubi_create(client, name, base_bdev, image_path, stripe_size_mb):
+    """Construct a ubi block device.
+    Args:
+        name: name of the ubi bdev to create
+        base_bdev: block device to store and read modified data
+        image_path: base image path
+        stripe_size_mb: unit size for fetching data from the base image
+    """
+    params = {
+        'name': name,
+        'image_path': image_path,
+        'base_bdev': base_bdev,
+        'stripe_size_mb': stripe_size_mb
+    }
+    return client.call('bdev_ubi_create', params)
+
+
+def bdev_ubi_delete(client, name):
+    """Delete ubi block device.
+    Args:
+        name: name of the ubi bdev to delete
+    """
+    params = {'name': name}
+    return client.call('bdev_ubi_delete', params)
+
+
 def bdev_null_create(client, num_blocks, block_size, name, physical_block_size=None, uuid=None, md_size=None,
                      dif_type=None, dif_is_head_of_md=None):
     """Construct a null block device.

--- a/scripts/rpc.py
+++ b/scripts/rpc.py
@@ -419,6 +419,28 @@ if __name__ == "__main__":
     p.add_argument('name', help='malloc bdev name')
     p.set_defaults(func=bdev_malloc_delete)
 
+    def bdev_ubi_create(args):
+        print_json(rpc.bdev.bdev_ubi_create(args.client,
+                                            name=args.name,
+                                            base_bdev=args.base_bdev,
+                                            image_path=args.image_path,
+                                            stripe_size_mb=args.stripe_size_mb))
+
+    p = subparsers.add_parser('bdev_ubi_create', help='Creates a ubi bdev')
+    p.add_argument('-n', '--name', help='ubi bdev name', required=True)
+    p.add_argument('-i', '--image-path', help='image path', required=True)
+    p.add_argument('-z', '--stripe-size-mb', help='stripe size in MB', type=int, required=False)
+    p.add_argument('-b', '--base-bdev', help='base bdev name', required=True)
+    p.set_defaults(func=bdev_ubi_create)
+
+    def bdev_ubi_delete(args):
+        rpc.bdev.bdev_ubi_delete(args.client,
+                                 name=args.name)
+
+    p = subparsers.add_parser('bdev_ubi_delete', help='Deletes a ubi bdev')
+    p.add_argument('name', help='ubi bdev name')
+    p.set_defaults(func=bdev_ubi_delete)
+
     def bdev_null_create(args):
         num_blocks = (args.total_size * 1024 * 1024) // args.block_size
         if args.dif_type and not args.md_size:

--- a/test/ubi/ubi.sh
+++ b/test/ubi/ubi.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+#  SPDX-License-Identifier: BSD-3-Clause
+#  Copyright (C) 2019 Intel Corporation
+#  All rights reserved.
+#
+set -e
+
+testdir=$(readlink -f $(dirname $0))
+rootdir=$(readlink -f $testdir/../..)
+plugindir=$rootdir/examples/bdev/fio_plugin
+source "$rootdir/scripts/common.sh"
+source "$rootdir/test/common/autotest_common.sh"
+source "$rootdir/test/nvmf/common.sh"
+
+# Declare rpc_py here, because its default value points to rpc_cmd function,
+# which does not tolerate piping arguments into it.
+rpc_py="$rootdir/scripts/rpc.py"
+
+
+function run_bdevio() {
+	$rootdir/test/bdev/bdevio/bdevio -w &
+	bdevio_pid=$!
+	trap 'killprocess $bdevio_pid; exit 1' SIGKILL SIGINT SIGTERM EXIT
+	waitforlisten $bdevio_pid
+	$rpc_py bdev_malloc_create -b Malloc0 128 512
+	rm -rf /tmp/ubi_image
+	touch /tmp/ubi_image
+	truncate -s 2M /tmp/ubi_image
+	$rpc_py bdev_ubi_create -n ubi0 -b Malloc0 -i /tmp/ubi_image -z 1
+	$rootdir/test/bdev/bdevio/tests.py perform_tests -b ubi0
+	trap - SIGKILL SIGINT SIGTERM EXIT
+	kill $bdevio_pid
+}
+
+run_bdevio


### PR DESCRIPTION
bdev_ubi provides an SPDK virtual bdev layered over another bdev, enabling copy-on-access for a base image.

This can be utilized to set up a block device initialized with an image file, without the delay of an initial copy. With bdev_ubi, copying occurs lazily upon block access, rather than at the provisioning time.

For instance, let's say you already have a bdev named "aio0" and you wish to populate it with data from `/opt/images/large-image.raw`. A conventional approach would be to copy `jammy.raw` to `aio0` using tools like spdk_dd, which can be time-consuming. However, with bdev_ubi, you can proceed as follows:

```
rpc.py bdev_ubi_create -n ubi0 -b aio0 \
  -i /opt/images/large-image.raw
```

and rather than directly using `aio0`, use `ubi0` as the block device. This action completes almost instantly, eliminating the need for initial data copying. The actual data copying will occur lazily during I/O requests.